### PR TITLE
Features/chart

### DIFF
--- a/functions/complaints.js
+++ b/functions/complaints.js
@@ -1,17 +1,73 @@
-export async function onRequestGet({ env }) {
+// functions/complaints.js
+export async function onRequestGet({ request, env }) {
   try {
     if (!env.KRN_DB) throw new Error("KRN_DB binding missing");
-    const rows = await env.KRN_DB.prepare(
-      `SELECT id, message, created_at
-         FROM complaints
-        ORDER BY datetime(created_at) DESC
-        LIMIT 50`
-    ).all();
-    return new Response(JSON.stringify(rows.results || []), {
-      headers: { "content-type": "application/json" }
+
+    const url = new URL(request.url);
+
+    // --- single item reveal: /complaints?id=...&reveal=1 ---
+    const id = url.searchParams.get("id");
+    const reveal = url.searchParams.get("reveal");
+    if (id && reveal) {
+      const row = await env.KRN_DB
+        .prepare(
+          `SELECT id, message, created_at
+             FROM complaints
+            WHERE id = ?`
+        )
+        .bind(id)
+        .first();
+
+      return json({
+        ok: true,
+        complaint: row || null,
+      });
+    }
+
+    // --- list endpoint with limit + before cursor ---
+    const limit = clampInt(url.searchParams.get("limit"), 50, 1, 200); // default 50, max 200
+    const before = url.searchParams.get("before"); // ISO string or millis
+
+    let sql = `SELECT id, message, created_at
+                 FROM complaints `;
+    const bind = [];
+
+    if (before) {
+      // Accept both ISO and numeric ms
+      let beforeVal = before;
+      if (/^\d+$/.test(before)) {
+        // milliseconds
+        beforeVal = new Date(Number(before)).toISOString();
+      }
+      sql += `WHERE datetime(created_at) < datetime(?) `;
+      bind.push(beforeVal);
+    }
+
+    sql += `ORDER BY datetime(created_at) DESC
+            LIMIT ?`;
+    bind.push(limit);
+
+    const r = await env.KRN_DB.prepare(sql).bind(...bind).all();
+
+    // Return an array (keeps compatibility with your current feed.js)
+    return new Response(JSON.stringify(r.results || []), {
+      headers: { "content-type": "application/json" },
     });
   } catch (e) {
     console.error("complaints error:", e);
     return new Response("Server error", { status: 500 });
   }
+}
+
+/* ---------------- helpers ---------------- */
+function clampInt(v, def, min, max) {
+  const n = parseInt(v ?? def, 10);
+  return Number.isFinite(n) ? Math.max(min, Math.min(max, n)) : def;
+}
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
 }

--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
           </p>
       <div id="feed" class="card feed">
         <div class="muted s">Loading…</div>
+        <div id="feed-controls" class="center">
+  <button id="olderBtn" class="btn s">Load older</button>
+</div>
+
       </div>
     </aside>
 

--- a/index.html
+++ b/index.html
@@ -75,11 +75,10 @@
           </p>
       <div id="feed" class="card feed">
         <div class="muted s">Loading…</div>
-        <div id="feed-controls" class="center">
+      </div>
+              <div id="feed-controls" class="center">
   <button id="olderBtn" class="btn s">Load older</button>
 </div>
-
-      </div>
     </aside>
 
 <!-- Price / Activity chart -->

--- a/index.html
+++ b/index.html
@@ -76,8 +76,9 @@
       <div id="feed" class="card feed">
         <div class="muted s">Loading…</div>
       </div>
-              <div id="feed-controls" class="center">
-  <button id="olderBtn" class="btn s">Load older</button>
+<div id="feed-nav" class="feed-nav">
+  <a href="#" id="newer-link" class="feed-link hidden">← Newer</a>
+  <a href="#" id="older-link" class="feed-link">Older →</a>
 </div>
     </aside>
 

--- a/public/feed.js
+++ b/public/feed.js
@@ -5,6 +5,9 @@ import { censorText } from "./censor.js";
   const feedEl = document.getElementById("feed");
   if (!feedEl) return;
 
+  /* ---------------- Config for paging ---------------- */
+  const FETCH_LIMIT = 50; // how many per page
+
   /* ---------------- Utils ---------------- */
   const $esc = (s) =>
     String(s)
@@ -13,13 +16,6 @@ import { censorText } from "./censor.js";
       .replaceAll(">", "&gt;")
       .replaceAll('"', "&quot;")
       .replaceAll("'", "&#039;");
-      
-const olderBtn = document.getElementById("olderBtn");
-let cursor = null; // last visible item’s created_at (or id)
-
-olderBtn?.addEventListener("click", () => {
-  load({ append: true });
-});
 
   const toB64 = (s) => btoa(unescape(encodeURIComponent(String(s))));
   const fromB64 = (b) => decodeURIComponent(escape(atob(String(b))));
@@ -54,23 +50,86 @@ olderBtn?.addEventListener("click", () => {
     return "";
   };
 
-  /* ---------------- Load feed ---------------- */
-  async function load() {
+  /* ---------------- Inject “Older/Newer” text links (no HTML edits needed) ---------------- */
+  const nav = document.getElementById("feed-nav") || (() => {
+    const d = document.createElement("div");
+    d.id = "feed-nav";
+    d.className = "feed-nav";
+    d.innerHTML = `
+      <a href="#" id="newer-link" class="feed-link hidden">← Newer</a>
+      <a href="#" id="older-link" class="feed-link">Older →</a>
+    `;
+    feedEl.insertAdjacentElement("afterend", d);
+    return d;
+  })();
+  const olderLink = nav.querySelector("#older-link");
+  const newerLink = nav.querySelector("#newer-link");
+
+  // lightweight styles if you haven't added CSS; safe to omit
+  if (!document.getElementById("feed-nav-inline-style")) {
+    const style = document.createElement("style");
+    style.id = "feed-nav-inline-style";
+    style.textContent = `
+      .feed-link{display:inline-block;margin:.5rem .75rem;font-size:.9rem;color:var(--accent);text-decoration:none;opacity:.9;cursor:pointer}
+      .feed-link:hover{text-decoration:underline;opacity:1}
+      .feed-link.hidden{display:none}
+    `;
+    document.head.appendChild(style);
+  }
+
+  /* ---------------- Paging state ---------------- */
+  let cursor = null;     // created_at of last visible item (for /complaints?before=…)
+  let hasHistory = false; // whether we've paged older at least once
+
+  /* ---------------- Load feed (supports append + cursor) ---------------- */
+  async function load({ append = false } = {}) {
     try {
-      const res = await fetch("/complaints?limit=120", { cache: "no-store" });
+      const url = new URL("/complaints", location.origin);
+      url.searchParams.set("limit", String(FETCH_LIMIT));
+      if (append && cursor) url.searchParams.set("before", cursor);
+
+      const res = await fetch(url.toString(), { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json();
-      const list = normalizeList(json);
+      const list = normalizeList(await res.json());
 
       if (!list.length) {
-        feedEl.innerHTML = `<div class="muted s">No complaints yet.</div>`;
+        if (!append) {
+          feedEl.innerHTML = `<div class="muted s">No complaints yet.</div>`;
+        }
+        // if no more, hide Older
+        olderLink?.classList.add("hidden");
         return;
       }
 
-      feedEl.innerHTML = list.map(renderItem).join("");
+      const html = list.map(renderItem).join("");
+
+      if (append) {
+        feedEl.insertAdjacentHTML("beforeend", html);
+        hasHistory = true;
+      } else {
+        feedEl.innerHTML = html;
+        hasHistory = false;
+      }
+
+      // move cursor to the last item we just drew
+      const last = list[list.length - 1];
+      cursor =
+        last?.created_at ??
+        last?.createdAt ??
+        last?.time ??
+        last?.timestamp ??
+        null;
+
+      // toggle links
+      // show Older if we likely have more (equal page size)
+      if (olderLink) olderLink.classList.toggle("hidden", list.length < FETCH_LIMIT);
+      // show Newer only if we’ve gone into history
+      if (newerLink) newerLink.classList.toggle("hidden", !hasHistory);
     } catch (e) {
       console.error("feed load error:", e);
-      feedEl.innerHTML = `<div class="muted s">Could not load complaints.</div>`;
+      if (!append) {
+        feedEl.innerHTML = `<div class="muted s">Could not load complaints.</div>`;
+      }
     }
   }
 
@@ -134,12 +193,11 @@ olderBtn?.addEventListener("click", () => {
           fullRaw = extractFullText(payload);
         } catch {}
 
+        // fallback to embedded original if API didn't provide it
         if (!fullRaw) {
           const b64 = itemEl.getAttribute("data-raw-b64") || "";
           if (b64) {
-            try {
-              fullRaw = fromB64(b64);
-            } catch {}
+            try { fullRaw = fromB64(b64); } catch {}
           }
         }
 
@@ -160,5 +218,22 @@ olderBtn?.addEventListener("click", () => {
     }
   });
 
+  /* ---------------- History link handlers ---------------- */
+  olderLink?.addEventListener("click", (e) => {
+    e.preventDefault();
+    if (!olderLink.classList.contains("hidden")) {
+      load({ append: true });
+    }
+  });
+
+  newerLink?.addEventListener("click", (e) => {
+    e.preventDefault();
+    // reset to newest page
+    cursor = null;
+    hasHistory = false;
+    load({ append: false });
+  });
+
+  // initial load
   load();
 })();

--- a/public/styles.css
+++ b/public/styles.css
@@ -305,7 +305,7 @@ textarea{ min-height:10rem }
 /* Reveal link */
 .reveal-link{
   display: inline-block;
-  margin-top: .25rem;
+  margin-top: .23rem;
   font-size: .9rem;
   color: var(--accent);
   text-decoration: none;
@@ -315,7 +315,7 @@ textarea{ min-height:10rem }
 .reveal-link.is-loading{ pointer-events: none; opacity: .6; }
 
 /* Extra compact when there is NO reveal link (short posts) */
-.item:not(:has(.reveal-link)){ padding-bottom: .3rem; }
+.item:not(:has(.reveal-link)){ padding-bottom: .1rem; }
 .item:not(:has(.reveal-link)) .msg{ margin: .1rem 0; }
 
 /* Helpers your JS already uses */

--- a/public/styles.css
+++ b/public/styles.css
@@ -255,44 +255,69 @@ textarea{ min-height:10rem }
 .holders .addr { opacity:.8; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width: 70%; }
 .holders .amt { font-weight:600; }
 
-/* Feed item compact mode when no reveal link */
-.item {
-  padding: .55rem .25rem;
+.inline { display: inline; }
+.hidden { display: none !important; }
+
+/* ---- Feed Items (clean + compact) ---- */
+
+/* Base item */
+.item{
+  padding: .45rem .25rem;              /* compact by default */
   border-bottom: 1px solid #3a2415;
 }
-.item:last-child { border-bottom: 0; }
+.item:last-child{ border-bottom: 0; }
 
-.item .time {
-  margin-bottom: .2rem;
+.item .time{
   font-size: .8rem;
   color: var(--muted);
+  margin: .2rem 0 .15rem;
 }
-.item .msg {
+
+.item .msg{
   margin: 0;
-  white-space: pre-wrap;
+  white-space: pre-wrap;               /* keep author line breaks in full view */
   word-break: break-word;
 }
 
-/* If no reveal link inside the item → compact spacing */
-.item:not(:has(.reveal-link)) {
-  padding-bottom: .35rem;
-}
-.item:not(:has(.reveal-link)) .msg {
-  margin-bottom: 0;
+/* 2-line preview for the SHORT variant only */
+.item .msg [data-variant="short"]{
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;               /* <-- show two lines */
+  overflow: hidden;
+
+  /* make <pre> behave like a paragraph for preview */
+  white-space: normal;
+  line-height: 1.4;
+  max-height: calc(2 * 1.4em);
+
+  /* subtle bottom fade so truncation looks intentional */
+  -webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
+          mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
 }
 
-/* Reveal link styling */
-.reveal-link {
+/* Full variant (shown when your JS toggles) */
+.item .msg [data-variant="full"]{
+  display: inline;
+  white-space: pre-wrap;
+}
+
+/* Reveal link */
+.reveal-link{
   display: inline-block;
-  margin-top: .3rem;
+  margin-top: .25rem;
   font-size: .9rem;
   color: var(--accent);
   text-decoration: none;
   opacity: .9;
 }
-.reveal-link:hover { text-decoration: underline; opacity: 1; }
-.reveal-link.is-loading { pointer-events: none; opacity: .6; }
+.reveal-link:hover{ text-decoration: underline; opacity: 1; }
+.reveal-link.is-loading{ pointer-events: none; opacity: .6; }
 
-/* Inline toggle helpers */
-.inline { display: inline; }
-.hidden { display: none !important; }
+/* Extra compact when there is NO reveal link (short posts) */
+.item:not(:has(.reveal-link)){ padding-bottom: .3rem; }
+.item:not(:has(.reveal-link)) .msg{ margin: .1rem 0; }
+
+/* Helpers your JS already uses */
+.inline{ display: inline; }
+.hidden{ display: none !important; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -297,5 +297,14 @@ textarea{ min-height:10rem }
 .inline { display: inline; }
 .hidden { display: none !important; }
 
-#feed-controls { margin-top: .5rem; }
-#olderBtn[disabled] { opacity:.5; cursor:not-allowed; }
+.feed-link {
+  display: inline-block;
+  margin: .5rem .75rem;
+  font-size: .9rem;
+  color: var(--accent);
+  text-decoration: none;
+  opacity: .9;
+  cursor: pointer;
+}
+.feed-link:hover { text-decoration: underline; opacity: 1; }
+.feed-link.hidden { display: none; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -279,19 +279,21 @@ textarea{ min-height:10rem }
   word-break: break-word;
 }
 
-/* 2-line preview for the SHORT variant only */
+/* Full text should wrap normally when revealed */
+.item .msg [data-variant="full"]{
+  display: inline;
+  white-space: pre-wrap;
+}
+
+/* Two‑line clamp applies only to preview */
 .item .msg [data-variant="short"]{
   display: -webkit-box;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;               /* <-- show two lines */
+  -webkit-line-clamp: 2;
   overflow: hidden;
-
-  /* make <pre> behave like a paragraph for preview */
   white-space: normal;
   line-height: 1.4;
   max-height: calc(2 * 1.4em);
-
-  /* subtle bottom fade so truncation looks intentional */
   -webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
           mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -255,71 +255,47 @@ textarea{ min-height:10rem }
 .holders .addr { opacity:.8; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width: 70%; }
 .holders .amt { font-weight:600; }
 
-.inline { display: inline; }
-.hidden { display: none !important; }
-
-/* ---- Feed Items (clean + compact) ---- */
-
-/* Base item */
-.item{
-  padding: .45rem .25rem;              /* compact by default */
+/* Feed item compact mode when no reveal link */
+.item {
+  padding: .55rem .25rem;
   border-bottom: 1px solid #3a2415;
 }
-.item:last-child{ border-bottom: 0; }
+.item:last-child { border-bottom: 0; }
 
-.item .time{
+.item .time {
+  margin-bottom: .2rem;
   font-size: .8rem;
   color: var(--muted);
-  margin: .2rem 0 .15rem;
 }
-
-.item .msg{
+.item .msg {
   margin: 0;
-  white-space: pre-wrap;               /* keep author line breaks in full view */
+  white-space: pre-wrap;
   word-break: break-word;
 }
 
-/* Full text should wrap normally when revealed */
-.item .msg [data-variant="full"]{
-  display: inline;
-  white-space: pre-wrap;
+/* If no reveal link inside the item → compact spacing */
+.item:not(:has(.reveal-link)) {
+  padding-bottom: .35rem;
+}
+.item:not(:has(.reveal-link)) .msg {
+  margin-bottom: 0;
 }
 
-/* Two‑line clamp applies only to preview */
-.item .msg [data-variant="short"]{
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
-  white-space: normal;
-  line-height: 1.4;
-  max-height: calc(2 * 1.4em);
-  -webkit-mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
-          mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, rgba(0,0,0,0));
-}
-
-/* Full variant (shown when your JS toggles) */
-.item .msg [data-variant="full"]{
-  display: inline;
-  white-space: pre-wrap;
-}
-
-/* Reveal link */
-.reveal-link{
+/* Reveal link styling */
+.reveal-link {
   display: inline-block;
-  margin-top: .23rem;
+  margin-top: .3rem;
   font-size: .9rem;
   color: var(--accent);
   text-decoration: none;
   opacity: .9;
 }
-.reveal-link:hover{ text-decoration: underline; opacity: 1; }
-.reveal-link.is-loading{ pointer-events: none; opacity: .6; }
+.reveal-link:hover { text-decoration: underline; opacity: 1; }
+.reveal-link.is-loading { pointer-events: none; opacity: .6; }
 
-/* Extra compact when there is NO reveal link (short posts) */
-.item:not(:has(.reveal-link)){ padding-bottom: .1rem; }
-.item:not(:has(.reveal-link)) .msg{ margin: .1rem 0; }
+/* Inline toggle helpers */
+.inline { display: inline; }
+.hidden { display: none !important; }
 
-/* Helpers your JS already uses */
-.inline{ display: inline; }
-.hidden{ display: none !important; }
+#feed-controls { margin-top: .5rem; }
+#olderBtn[disabled] { opacity:.5; cursor:not-allowed; }


### PR DESCRIPTION
feat(feed): add text-based history navigation with Older/Newer links

Replaced button requirement with inline text links below the feed

Implemented cursor-based pagination (before param) for loading next 50 items

Added "Older →" link to fetch additional history and append results

Added "← Newer" link to reset view back to the latest feed items

Preserved censor + reveal logic without modification to existing behavior